### PR TITLE
修复设置卡片与阅读跟随状态

### DIFF
--- a/src/client/useProgressiveDomText.ts
+++ b/src/client/useProgressiveDomText.ts
@@ -18,6 +18,15 @@ interface TextRevealRecord {
   shown: number
 }
 
+/**
+ * Persistent reveal ledger per root: the follow wrapper can flip a Tool row
+ * off (structural settle) and straight back on (live tail) in adjacent
+ * layout effects. A fresh effect-local ledger would restore the full text and
+ * then blank-and-replay it; keeping one ledger per root makes re-entry a
+ * no-op for already-shown text and only paces genuinely new mutations.
+ */
+const ledgerByRoot = new WeakMap<HTMLElement, Map<Text, TextRevealRecord>>()
+
 const SKIP_TEXT_SELECTOR = [
   '[aria-hidden="true"]',
   '[aria-live]',
@@ -60,7 +69,11 @@ export function useProgressiveDomText(
     const root = rootRef.current
     if (root === null || typeof document === 'undefined') return
 
-    const records = new Map<Text, TextRevealRecord>()
+    let records = ledgerByRoot.get(root)
+    if (records === undefined) {
+      records = new Map<Text, TextRevealRecord>()
+      ledgerByRoot.set(root, records)
+    }
     const pending = new Set<Text>()
     const internalWrites = new WeakMap<Text, string>()
     let rafId = 0
@@ -221,7 +234,13 @@ export function useProgressiveDomText(
         // React may have committed a terminal replacement in the same mutation
         // phase that disables this hook. Never overwrite that newer renderer
         // value with the previous controlled source during layout cleanup.
-        if (node.isConnected && node.data === controlled) write(node, record.full)
+        if (node.isConnected && node.data === controlled) {
+          write(node, record.full)
+          // The restore presents the full source synchronously; mark the
+          // ledger settled so an immediate re-enable does not blank and
+          // replay already-visible text.
+          records.set(node, { ...record, shown: record.chars.length })
+        }
       }
       pending.clear()
       speedCpsRef.current = 35

--- a/src/client/useProgressiveDomText.ts
+++ b/src/client/useProgressiveDomText.ts
@@ -18,13 +18,7 @@ interface TextRevealRecord {
   shown: number
 }
 
-/**
- * Persistent reveal ledger per root: the follow wrapper can flip a Tool row
- * off (structural settle) and straight back on (live tail) in adjacent
- * layout effects. A fresh effect-local ledger would restore the full text and
- * then blank-and-replay it; keeping one ledger per root makes re-entry a
- * no-op for already-shown text and only paces genuinely new mutations.
- */
+/** Last presented text per root, retained across follow lifecycle flips. */
 const ledgerByRoot = new WeakMap<HTMLElement, Map<Text, TextRevealRecord>>()
 
 const SKIP_TEXT_SELECTOR = [
@@ -65,15 +59,58 @@ export function useProgressiveDomText(
   onSettled?: (() => void) | undefined,
 ): void {
   useLayoutEffect(() => {
-    if (!enabled) return
     const root = rootRef.current
     if (root === null || typeof document === 'undefined') return
 
     let records = ledgerByRoot.get(root)
+    if (!enabled && records === undefined) return
     if (records === undefined) {
       records = new Map<Text, TextRevealRecord>()
       ledgerByRoot.set(root, records)
     }
+
+    const forEachText = (from: Node, callback: (text: Text) => void): void => {
+      if (from.nodeType === Node.TEXT_NODE) {
+        callback(from as Text)
+        return
+      }
+      const walker = document.createTreeWalker(from, NodeFilter.SHOW_TEXT)
+      let current = walker.nextNode()
+      while (current !== null) {
+        callback(current as Text)
+        current = walker.nextNode()
+      }
+    }
+
+    const settle = (text: Text): void => {
+      if (!revealable(text, root)) return
+      const chars = [...text.data]
+      records.set(text, { chars, full: text.data, shown: chars.length })
+    }
+
+    const snapshotVisible = (): void => {
+      const current = new Set<Text>()
+      forEachText(root, (text) => {
+        if (!revealable(text, root)) return
+        current.add(text)
+        settle(text)
+      })
+      for (const text of records.keys()) {
+        if (!current.has(text)) records.delete(text)
+      }
+    }
+
+    if (!enabled) {
+      snapshotVisible()
+      const observer = typeof MutationObserver === 'undefined'
+        ? null
+        : new MutationObserver(snapshotVisible)
+      observer?.observe(root, { childList: true, characterData: true, subtree: true })
+      return () => {
+        observer?.disconnect()
+      }
+    }
+
     const pending = new Set<Text>()
     const internalWrites = new WeakMap<Text, string>()
     let rafId = 0
@@ -117,18 +154,22 @@ export function useProgressiveDomText(
     }
 
     const visit = (from: Node, reveal: boolean): void => {
-      if (from.nodeType === Node.TEXT_NODE) {
-        const text = from as Text
-        if (reveal) enqueue(text, text.data, records.get(text))
-        return
-      }
-      const walker = document.createTreeWalker(from, NodeFilter.SHOW_TEXT)
-      let current = walker.nextNode()
-      while (current !== null) {
-        const text = current as Text
-        if (reveal) enqueue(text, text.data, records.get(text))
-        current = walker.nextNode()
-      }
+      forEachText(from, (text) => {
+        if (!revealable(text, root)) return
+        if (reveal) {
+          enqueue(text, text.data, records.get(text))
+          return
+        }
+        settle(text)
+      })
+    }
+
+    const forget = (from: Node): void => {
+      forEachText(from, (text) => {
+        if (root.contains(text)) return
+        records.delete(text)
+        pending.delete(text)
+      })
     }
 
     const scheduleFrame = (): void => {
@@ -200,7 +241,7 @@ export function useProgressiveDomText(
       else scheduleFrame()
     }
 
-    if (revealInitial) visit(root, true)
+    visit(root, revealInitial)
 
     const observer = typeof MutationObserver === 'undefined'
       ? null
@@ -216,6 +257,7 @@ export function useProgressiveDomText(
               enqueue(node, node.data, records.get(node))
               continue
             }
+            for (const removed of mutation.removedNodes) forget(removed)
             for (const added of mutation.addedNodes) visit(added, true)
           }
           if (pending.size === 0) announceSettled()
@@ -236,10 +278,6 @@ export function useProgressiveDomText(
         // value with the previous controlled source during layout cleanup.
         if (node.isConnected && node.data === controlled) {
           write(node, record.full)
-          // The restore presents the full source synchronously; mark the
-          // ledger settled so an immediate re-enable does not blank and
-          // replay already-visible text.
-          records.set(node, { ...record, shown: record.chars.length })
         }
       }
       pending.clear()

--- a/tests/settings-card.client.spec.tsx
+++ b/tests/settings-card.client.spec.tsx
@@ -182,6 +182,18 @@ describe('smooth-stream settings card', () => {
     expect(inject).toEqual(['slots'])
   })
 
+  it('registers the namespace as the keyed slot key for the configurable tab', async () => {
+    const { ctx, slots } = await bench()
+    slots.register({
+      name: 'root',
+      children: { 'settings.plugin.item': { kind: 'keyed', scope: 'root' } },
+    } as never, () => null)
+    await ctx.plugin({ inject: [...inject], apply }).await()
+
+    expect(slots.entries('settings.plugin.item').map(entry => entry.options.key))
+      .toEqual(['smooth-stream'])
+  })
+
   it('registers the card once the plugin-item slot is declared', async () => {
     const { ctx, slots } = await bench()
     declareCardSlot(slots)

--- a/tests/stream.client.spec.tsx
+++ b/tests/stream.client.spec.tsx
@@ -120,6 +120,13 @@ function ProgressiveDomProbe({ text }: { text: string }) {
   return <div ref={rootRef}>{text}</div>
 }
 
+function FollowToggleProgressiveDomProbe({ enabled, text }: { enabled: boolean; text: string }) {
+  const rootRef = useRef<HTMLDivElement>(null)
+  const speedCpsRef = useRef(35)
+  useProgressiveDomText(rootRef, enabled, true, speedCpsRef)
+  return <div ref={rootRef}>{text}</div>
+}
+
 function CompetingFollowProbe({ secondary }: { secondary: boolean }) {
   const primaryRef = useRef<HTMLDivElement>(null)
   const secondaryRef = useRef<HTMLDivElement>(null)
@@ -2988,43 +2995,94 @@ describe('isGrowingChatNode', () => {
 
   it('keeps already-revealed text when the follow flip restores and re-enables', async () => {
     vi.useFakeTimers({ toFake: [...FAKE] })
-    function FlipProgressiveProbe({ enabled, text }: { enabled: boolean; text: string }) {
-      const rootRef = useRef<HTMLDivElement>(null)
-      const speedCpsRef = useRef(35)
-      useProgressiveDomText(rootRef, enabled, true, speedCpsRef)
-      return <div ref={rootRef}>{text}</div>
-    }
-    const view = render(<FlipProgressiveProbe enabled text="Tool invoked" />)
+    const view = render(<FollowToggleProgressiveDomProbe enabled text="Tool invoked" />)
     await act(() => vi.advanceTimersByTimeAsync(400))
     expect(view.container.textContent).toBe('Tool invoked')
 
     // Tool row settles: structural follow drops, the hook restores full text.
-    view.rerender(<FlipProgressiveProbe enabled={false} text="Tool invoked" />)
+    view.rerender(<FollowToggleProgressiveDomProbe enabled={false} text="Tool invoked" />)
     await act(async () => {})
     expect(view.container.textContent).toBe('Tool invoked')
 
-    // The live turn tail re-arms follow in the next layout pass. Without a
-    // persistent ledger this re-enable blanks the row from an empty ledger
-    // and replays the already-visible text.
-    view.rerender(<FlipProgressiveProbe enabled text="Tool invoked" />)
+    // The live turn tail re-arms follow in the next layout pass. Without
+    // retaining the root's activation state, a fresh ledger would blank and
+    // replay the already-visible text.
+    view.rerender(<FollowToggleProgressiveDomProbe enabled text="Tool invoked" />)
     await act(async () => {})
     expect(view.container.textContent).toBe('Tool invoked')
     await act(() => vi.advanceTimersByTimeAsync(400))
     expect(view.container.textContent).toBe('Tool invoked')
   })
 
+  it('keeps text that became visible while follow was disabled', async () => {
+    vi.useFakeTimers({ toFake: [...FAKE] })
+    const view = render(<FollowToggleProgressiveDomProbe enabled text="Tool" />)
+    await act(() => vi.advanceTimersByTimeAsync(400))
+    expect(view.container.textContent).toBe('Tool')
+
+    view.rerender(<FollowToggleProgressiveDomProbe enabled={false} text="Tool" />)
+    await act(async () => {})
+    view.rerender(<FollowToggleProgressiveDomProbe enabled={false} text="Tool result" />)
+    await act(async () => {})
+    expect(view.container.textContent).toBe('Tool result')
+
+    view.rerender(<FollowToggleProgressiveDomProbe enabled text="Tool result" />)
+    await act(async () => {})
+    expect(view.container.textContent).toBe('Tool result')
+  })
+
+  it('paces only new text committed when follow re-enables', async () => {
+    vi.useFakeTimers({ toFake: [...FAKE] })
+    const view = render(<FollowToggleProgressiveDomProbe enabled text="Tool" />)
+    await act(() => vi.advanceTimersByTimeAsync(400))
+    expect(view.container.textContent).toBe('Tool')
+
+    view.rerender(<FollowToggleProgressiveDomProbe enabled={false} text="Tool" />)
+    await act(async () => {})
+    view.rerender(<FollowToggleProgressiveDomProbe enabled text="Tool result" />)
+    await act(async () => {})
+    expect(view.container.textContent).toBe('Tool')
+
+    await act(() => vi.advanceTimersByTimeAsync(400))
+    expect(view.container.textContent).toBe('Tool result')
+  })
+
+  it('keeps initial reveal pacing through StrictMode effect replay', async () => {
+    vi.useFakeTimers({ toFake: [...FAKE] })
+    const text = 'StrictMode should not mark a fresh renderer as already revealed.'
+    const view = render(
+      <StrictMode>
+        <FollowToggleProgressiveDomProbe enabled text={text} />
+      </StrictMode>,
+    )
+
+    expect(view.container.textContent).not.toBe(text)
+    await act(() => vi.advanceTimersByTimeAsync(1600))
+    expect(view.container.textContent).toBe(text)
+  })
+
   it('does not animate a completed historical context row', async () => {
     vi.useFakeTimers({ toFake: [...FAKE] })
-    let observerCount = 0
+    let resizeObserverCount = 0
+    let mutationObserverCount = 0
     class ResizeObserverStub {
       constructor(_callback: ResizeObserverCallback) {
-        observerCount += 1
+        resizeObserverCount += 1
+      }
+
+      observe(): void {}
+      disconnect(): void {}
+    }
+    class MutationObserverStub {
+      constructor(_callback: MutationCallback) {
+        mutationObserverCount += 1
       }
 
       observe(): void {}
       disconnect(): void {}
     }
     vi.stubGlobal('ResizeObserver', ResizeObserverStub)
+    vi.stubGlobal('MutationObserver', MutationObserverStub)
     function Inner() {
       return <div>historical context</div>
     }
@@ -3053,7 +3111,8 @@ describe('isGrowingChatNode', () => {
 
     expect(transcript.style.transform).toBe('')
     expect(port.getAttribute('data-follow-owned')).toBeNull()
-    expect(observerCount).toBe(0)
+    expect(resizeObserverCount).toBe(0)
+    expect(mutationObserverCount).toBe(0)
   })
 
   it('re-arms follow for a future Agent renderer when its DOM grows', async () => {

--- a/tests/stream.client.spec.tsx
+++ b/tests/stream.client.spec.tsx
@@ -2358,7 +2358,10 @@ describe('assistant renderer', () => {
     const surface = view.container.querySelector('[data-chat-transcript]') as HTMLElement
     const status = view.container.querySelector('[data-chat-turn-status]') as HTMLElement
     Object.defineProperty(port, 'clientHeight', { configurable: true, value: 100 })
-    Object.defineProperty(port, 'scrollHeight', { configurable: true, get: () => height })
+    Object.defineProperty(port, 'scrollHeight', {
+      configurable: true,
+      get: () => height + (Number.parseFloat(status.style.marginTop) || 0),
+    })
     vi.spyOn(surface, 'getBoundingClientRect').mockImplementation(() => {
       const shift = Number(/translate3d\(0, ([\d.]+)px, 0\)/.exec(surface.style.transform)?.[1] ?? 0)
       return { top: 0, bottom: 80 + shift } as DOMRect
@@ -2981,6 +2984,33 @@ describe('isGrowingChatNode', () => {
       requestFrame.mockRestore()
       cancelFrame.mockRestore()
     }
+  })
+
+  it('keeps already-revealed text when the follow flip restores and re-enables', async () => {
+    vi.useFakeTimers({ toFake: [...FAKE] })
+    function FlipProgressiveProbe({ enabled, text }: { enabled: boolean; text: string }) {
+      const rootRef = useRef<HTMLDivElement>(null)
+      const speedCpsRef = useRef(35)
+      useProgressiveDomText(rootRef, enabled, true, speedCpsRef)
+      return <div ref={rootRef}>{text}</div>
+    }
+    const view = render(<FlipProgressiveProbe enabled text="Tool invoked" />)
+    await act(() => vi.advanceTimersByTimeAsync(400))
+    expect(view.container.textContent).toBe('Tool invoked')
+
+    // Tool row settles: structural follow drops, the hook restores full text.
+    view.rerender(<FlipProgressiveProbe enabled={false} text="Tool invoked" />)
+    await act(async () => {})
+    expect(view.container.textContent).toBe('Tool invoked')
+
+    // The live turn tail re-arms follow in the next layout pass. Without a
+    // persistent ledger this re-enable blanks the row from an empty ledger
+    // and replays the already-visible text.
+    view.rerender(<FlipProgressiveProbe enabled text="Tool invoked" />)
+    await act(async () => {})
+    expect(view.container.textContent).toBe('Tool invoked')
+    await act(() => vi.advanceTimersByTimeAsync(400))
+    expect(view.container.textContent).toBe('Tool invoked')
   })
 
   it('does not animate a completed historical context row', async () => {


### PR DESCRIPTION
## 修复内容

- 修复插件配置卡片注册缺少 `smooth-stream` keyed namespace 的问题，使当前 DSH Web 的插件配置页能够正常分发该卡片。
- 修复工具调用行在跟随生命周期切换时已显示文本被清空并重新逐字播放的问题；follow 关闭期间已显示的新文本会被保留，重新启用时只渐进展示新提交的后缀。
- 修复读者手动接管滚动后残留 48px predictive runway，避免滚动到底部时出现短暂空白区域。该逻辑已与最新 `main` 的自然 floor handoff 修复对齐。

## 处理记录

- 已 rebase 到最新 `main`，保留 `main` 中已有的 keyed settings namespace 和 reader handoff 顺序修复。
- 已补充 keyed slot、follow flip、disabled 期间文本更新、重新启用时新增文本，以及历史行不创建 observer 的回归测试。

## 验证结果

- `pnpm typecheck`：通过。
- `pnpm test`：4 个测试文件、154 项通过。
- `pnpm build`：Host/Client 构建通过。
- `git diff --check`：通过。

完整测试不再依赖上游 `../deepseek-harness` 源码树。