### PR TITLE
fix: shift foreign flow siblings so injected rows are not painted over

### DIFF
--- a/src/client/teleprompterGlide.ts
+++ b/src/client/teleprompterGlide.ts
@@ -216,12 +216,32 @@ function resizeProxyOf(port: HTMLElement): HTMLElement | null {
   return port.querySelector('[data-chat-transcript]') ?? port.querySelector('[data-chat-flow]')
 }
 
-/** Outermost message surfaces; nested tool rows ride their parent. */
-function shiftSurfacesOf(port: HTMLElement): HTMLElement[] {
+/**
+ * Outermost message surfaces; nested tool rows ride their parent.
+ *
+ * Another plugin may insert its own element as a flow sibling of the Chat rows
+ * (meow-memory's fold bar is one). Such a row carries no
+ * `data-chat-anchor-key`, so selecting only anchored rows would shift the
+ * conversation while leaving the foreign row at its natural offset, letting the
+ * shifted rows paint over it. Every direct flow child therefore rides the same
+ * transform, keeping the visual order of the column intact.
+ */
+export function shiftSurfacesOf(port: HTMLElement): HTMLElement[] {
   const transcript = port.querySelector<HTMLElement>('[data-chat-transcript]')
   if (transcript !== null) return [transcript]
-  return [...port.querySelectorAll<HTMLElement>('[data-chat-anchor-key]')]
+  const anchored = [...port.querySelectorAll<HTMLElement>('[data-chat-anchor-key]')]
     .filter(row => row.parentElement?.closest('[data-chat-anchor-key]') === null)
+  const flow = port.querySelector<HTMLElement>('[data-chat-flow]')
+  if (flow === null) return anchored
+  const status = turnStatusOf(port)
+  const anchoredSet = new Set(anchored)
+  // One document-order pass: an anchored row, or a foreign child that contains
+  // no anchored row of its own (a wrapper around real rows would double-shift
+  // the rows inside it).
+  return [...flow.children].filter((child): child is HTMLElement =>
+    child instanceof HTMLElement
+    && child !== status
+    && (anchoredSet.has(child) || child.querySelector('[data-chat-anchor-key]') === null))
 }
 
 function currentShiftOf(element: HTMLElement): number {

--- a/tests/shift-surfaces.client.spec.tsx
+++ b/tests/shift-surfaces.client.spec.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+import { shiftSurfacesOf } from '../src/client/teleprompterGlide.ts'
+
+/**
+ * Build a conversation port whose flow column mixes harness Chat rows with a
+ * row injected by another plugin, which is the topology meow-memory produces.
+ * @param injected - whether to insert the foreign sibling.
+ * @returns the scroll port element.
+ */
+function buildPort(injected: boolean): HTMLElement {
+  const port = document.createElement('div')
+  port.setAttribute('data-conversation-scroll', '')
+  const flow = document.createElement('div')
+  flow.setAttribute('data-chat-flow', '')
+  port.appendChild(flow)
+
+  const first = document.createElement('div')
+  first.setAttribute('data-chat-anchor-key', '1:user')
+  flow.appendChild(first)
+
+  if (injected) {
+    const bar = document.createElement('div')
+    bar.setAttribute('data-meow-memory-anchor', '2:input')
+    flow.appendChild(bar)
+  }
+
+  const second = document.createElement('div')
+  second.setAttribute('data-chat-anchor-key', '2:assistant')
+  // A nested tool row must keep riding its parent rather than shifting twice.
+  const nested = document.createElement('div')
+  nested.setAttribute('data-chat-anchor-key', '2:tool')
+  second.appendChild(nested)
+  flow.appendChild(second)
+
+  const status = document.createElement('div')
+  status.setAttribute('role', 'status')
+  flow.appendChild(status)
+
+  return port
+}
+
+describe('shiftSurfacesOf', () => {
+  it('shifts a foreign flow sibling with the conversation so it cannot be painted over', () => {
+    const surfaces = shiftSurfacesOf(buildPort(true))
+    expect(surfaces.map(el => el.getAttribute('data-chat-anchor-key')
+      ?? el.getAttribute('data-meow-memory-anchor'))).toEqual([
+      '1:user',
+      '2:input',
+      '2:assistant',
+    ])
+  })
+
+  it('excludes the turn status and nested tool rows', () => {
+    const surfaces = shiftSurfacesOf(buildPort(false))
+    expect(surfaces.some(el => el.getAttribute('role') === 'status')).toBe(false)
+    expect(surfaces.map(el => el.getAttribute('data-chat-anchor-key'))).toEqual([
+      '1:user',
+      '2:assistant',
+    ])
+  })
+
+  it('keeps the single transcript surface when the conversation exposes one', () => {
+    const port = document.createElement('div')
+    const transcript = document.createElement('div')
+    transcript.setAttribute('data-chat-transcript', '')
+    const flow = document.createElement('div')
+    flow.setAttribute('data-chat-flow', '')
+    transcript.appendChild(flow)
+    port.appendChild(transcript)
+    expect(shiftSurfacesOf(port)).toEqual([transcript])
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,28 @@ import { fileURLToPath } from 'node:url'
 import { defineConfig, type Plugin } from 'vitest/config'
 
 const root = fileURLToPath(new URL('.', import.meta.url))
-const harnessRoot = resolve(root, '../deepseek-harness')
+
+/**
+ * The path map targets `../deepseek-harness`, which holds when this plugin is
+ * checked out beside the harness. A checkout inside the harness's own
+ * `local-plugins/` directory reaches the same tree two levels up, so resolve
+ * the sibling layout first and fall back to the nested one; without a hit the
+ * `@deepseek-ai/*` specifiers fall through to prebuilt client bundles that
+ * expect a loader global and throw on import.
+ */
+function findHarnessRoot(): string | null {
+  for (const candidate of [
+    resolve(root, '../deepseek-harness'),
+    resolve(root, '../..'),
+  ]) {
+    if (existsSync(join(candidate, 'packages')) && existsSync(join(candidate, 'vendor'))) {
+      return candidate
+    }
+  }
+  return null
+}
+
+const harnessRoot = findHarnessRoot()
 
 interface PathMap {
   compilerOptions: { paths: Record<string, string[]> }
@@ -37,13 +58,21 @@ function expandTarget(target: string, captured: string): string {
 }
 
 function harnessPathsPlugin(): Plugin | null {
-  if (!existsSync(harnessRoot)) return null
+  if (harnessRoot === null) return null
   const map = JSON.parse(readFileSync(join(root, 'tsconfig.paths.json'), 'utf8')) as PathMap
   const entries = Object.entries(map.compilerOptions.paths)
   const exact = new Map<string, string[]>()
   const wild: Array<{ pattern: string; targets: string[] }> = []
+  // Every target is written against the sibling layout; re-root it so a nested
+  // checkout resolves the same source files.
+  const reroot = (target: string): string => resolve(
+    root,
+    target.startsWith('../deepseek-harness/')
+      ? join(harnessRoot, target.slice('../deepseek-harness/'.length))
+      : target,
+  )
   for (const [pattern, targets] of entries) {
-    const resolved = targets.map(target => resolve(root, target))
+    const resolved = targets.map(reroot)
     if (pattern.includes('*')) wild.push({ pattern, targets: resolved })
     else exact.set(pattern, resolved)
   }


### PR DESCRIPTION
## Summary

Two independent fixes found while running this plugin alongside
[meow-memory](https://github.com/Phant0Meow/dsh-meow-memory) in a DSH web profile.

### 1. `fix:` foreign flow siblings were painted over at the scroll bottom

`shiftSurfacesOf` selected only `[data-chat-anchor-key]` rows. Another plugin may
insert its own element as a **flow sibling** of the Chat rows — meow-memory's
fold bar does exactly that, injecting a raw `div[data-meow-memory-anchor]` into
`[data-chat-flow]`. That element carries no `data-chat-anchor-key`, so while the
conversation sat at the scroll bottom the follow transform slid every real row
down by `FOLLOW_STATUS_RUNWAY_PX` and left the foreign row at its natural offset.
The shifted rows then painted over it, showing the bar's text through the
message.

Confirmed against the live DOM rather than inferred: the injected bars reported
`position: static; transform: none` while their sibling `flowItem` rows reported
`transform: matrix(1, 0, 0, 1, 0, 48.8422)`.

The fix walks the flow column in document order and shifts anchored rows and
foreign siblings alike, while still excluding the turn status and any wrapper
that contains real rows (which would double-shift the rows inside it).

### 2. `test:` client suites could not run from a nested checkout

`vitest.config.ts` resolved `@deepseek-ai/*` to harness sources only when it
found the harness at `../deepseek-harness` — the sibling layout. A checkout
inside the harness's own `local-plugins/` directory found no harness root, so the
redirect was skipped and the specifiers fell through to prebuilt client bundles
that expect a loader global:

```
TypeError: Cannot read properties of undefined (reading 'load')
 ❯ @deepseek-ai/dsh-client-runtime/lib/client.js:1:25
```

Three of the four suites failed at import, including `stream.client.spec.tsx`
(123 tests), so they had not been running in that layout at all. The config now
detects the sibling layout first and the nested one second, re-rooting each
mapped target accordingly.

## Testing

- `pnpm typecheck` — clean.
- `pnpm test` — **158 passed (5 files)**. Before fix 2, only `settings.host` (5
  tests) could load; the other three suites failed at import.
- New `tests/shift-surfaces.client.spec.tsx` covers the regression. I verified it
  actually catches the bug by reverting the fix, which fails with:
  `expected [ '1:user', '2:assistant' ] to deeply equal [ '1:user', '2:input', '2:assistant' ]`
  — the foreign row missing from the shifted set is precisely the defect.
- Verified in a running `dsh web` profile: the overlap is gone at the scroll
  bottom with meow-memory's fold bars present.

## Notes

Fix 2 is independent of fix 1 and can be dropped if the nested layout is out of
scope for this project — though without it the client suites are silently
skipped for anyone whose checkout lives inside the harness tree.
